### PR TITLE
bugfix: correct expiration of multiple accept offers that expire on a si...

### DIFF
--- a/msc_validate.py
+++ b/msc_validate.py
@@ -99,8 +99,10 @@ def add_alarm(tx_hash):
     alarm_block=tx_block+payment_timeframe
     if alarm.has_key(alarm_block):
         alarm[alarm_block].append(t)
+        debug('added alarm in block '+str(alarm_block)+' for '+tx_hash)
     else:
         alarm[alarm_block]=[t]
+        debug('added first alarm in block '+str(alarm_block)+' for '+tx_hash)
 
 def remove_alarm(tx_hash):
     t=tx_dict[tx_hash][-1] # last tx on the list
@@ -112,6 +114,7 @@ def remove_alarm(tx_hash):
     if alarm.has_key(alarm_block):
         try:
             alarm[alarm_block].remove(t)
+            debug('removed alarm at block '+str(alarm_block)+' for '+tx_hash)
         except ValueError:
             info('failed removing alarm for '+tx_hash)
     else:
@@ -123,6 +126,7 @@ def check_alarm(t, last_block, current_block):
     for b in range(last_block, current_block):
         if alarm.has_key(b):
             debug('alarm for block '+str(b))
+            debug('transaction checked in alarm for block are '+str(alarm[b]))
             for a in alarm[b]:
                 debug('verify payment for tx '+str(a['tx_hash']))
                 tx_hash=a['tx_hash']
@@ -208,9 +212,8 @@ def check_alarm(t, last_block, current_block):
                                     update_tx_dict(sell_tx['tx_hash'], color='bgc-new-accepted', icon_text='Sell offer partially accepted')
                     else:
                         info('BUG: remove alarm for accept without sell_offer_txid '+a['tx_hash'])
-                    # no need to check this accept any more
-                    debug('remove alarm for expired '+tx_hash)
-                    remove_alarm(tx_hash)
+                    # no need to check this accept any more, but leave on alarms dict
+                    debug('checked alarm for expired '+tx_hash)
                 else:
                     debug('accept offer '+tx_hash+' was already paid with '+a['btc_offer_txid'])
                     # update left over accept on buyer side


### PR DESCRIPTION
...ngle block

The mechanism that checks expiration of accept offers uses a dictionary
for alarms which contains expration block number as a key and a list of accept txid
that expire at that block.
While iterating on the list, the code removed checked accept txid from that list
In a case where multiple accept transactions expire in a single block, this removal
causes the second accept expiration to be skipped.
specifically, this unpaid accept offer was hanging in a non expired state:
https://masterchain.info/sellaccept.html?tx=5737353a669583964a296ef920837fd97ad5c89c3dee9e8216e674dad5c76c6e&currency=MSC
avoiding the removal of old alerts from this dictionary fixes the problem

This is the only case that such a problem has happened.
The effect was a wrong calculation of the following accept offer (missing 1.3 MSC):
https://masterchain.info/sellaccept.html?tx=d846fd98dcd268f835d272e13b8623fd2ca435060fa91baaf8426bffb067a5b1&currency=MSC
but since we could see that the later payment was correct, and the consensus support it,
I see no problem to correct this problem retrospective.

If the foundation insists, I could still keep the bug until current block.
