### PR TITLE
try local rpc then look for remote file config ~/.bitcoin/bitcoin.conf

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,17 @@ rpcuser=<username>
 rpcpassword=<password>
 rpcallowip=<local IP>
    ```
+   
+2b. Alternatively if you have a remote bitcoind instance you can use that as well. Create ``~/.bitcoin/bitcoin.conf`` with the following lines:
+
+   ```
+rpcuser=<remote username>
+rpcpassword=<remote password>
+rpcconnect=<Remote Server IP>
+rpcport=<Remote Port>
+   ```
+   
+Dont' forget to add a whitelist entry (rpcallowip) to your remote bitcoind (or bitcoin-qt) for the ip address of the script source
 
 3. Install libraries
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,7 +22,7 @@ rpcpassword=<password>
 rpcallowip=<local IP>
    ```
    
- Alternatively if you have a remote bitcoind instance you can use that as well. Create ``~/.bitcoin/bitcoin.conf`` with the following lines:
+ Alternatively if you have a remote bitcoind instance you can use that as well. On the machine where you will run the scripts create ``~/.bitcoin/bitcoin.conf`` with the following lines:
 
    ```
 rpcuser=<remote username>
@@ -31,7 +31,7 @@ rpcconnect=<Remote Server IP>
 rpcport=<Remote Port>
    ```
    
-Dont' forget to add a whitelist entry (rpcallowip) to your remote bitcoind (or bitcoin-qt) for the ip address of the script source
+ Dont' forget to add a whitelist entry (rpcallowip) to your remote bitcoind (or bitcoin-qt) for the ip address of the machine the scripts will run from. 
 
 3. Install libraries
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,7 +22,7 @@ rpcpassword=<password>
 rpcallowip=<local IP>
    ```
    
-2b. Alternatively if you have a remote bitcoind instance you can use that as well. Create ``~/.bitcoin/bitcoin.conf`` with the following lines:
+ Alternatively if you have a remote bitcoind instance you can use that as well. Create ``~/.bitcoin/bitcoin.conf`` with the following lines:
 
    ```
 rpcuser=<remote username>

--- a/scripts/generateTX50_SP.py
+++ b/scripts/generateTX50_SP.py
@@ -7,6 +7,7 @@ import hashlib
 import operator
 import bitcoinrpc
 import pybitcointools
+import getpass
 from decimal import *
 
 
@@ -25,7 +26,35 @@ JSON = sys.stdin.readlines()
 listOptions = json.loads(str(''.join(JSON)))
 
 #sort out whether using local or remote API
+USER=getpass.getuser()
+
+#sort out whether using local or remote API
 conn = bitcoinrpc.connect_to_local()
+try:
+    conn.getblockcount()
+except StandardError:
+    try:
+        with open('/home/'+USER+'/.bitcoin/bitcoin.conf') as fp:
+            RPCPORT="8332"
+            RPCHOST="localhost"
+            for line in fp:
+                #print line
+                if line.split('=')[0] == "rpcuser":
+                    RPCUSER=line.split('=')[1].strip()
+                elif line.split('=')[0] == "rpcpassword":
+                    RPCPASS=line.split('=')[1].strip()
+                elif line.split('=')[0] == "rpcconnect":
+                    RPCHOST=line.split('=')[1].strip()
+                elif line.split('=')[0] == "rpcport":
+                    RPCPORT=line.split('=')[1].strip()
+    except IOError as e:
+        print "Unable to open conf file: ~/.bitcoin/bitcoin.conf"
+        exit()
+    try:
+        conn = bitcoinrpc.connect_to_remote(RPCUSER,RPCPASS,host=RPCHOST,port=RPCPORT,use_https=False)
+    except StandardError:
+        print json.dumps({ "status": "NOT OK", "error": "Can't connect to bitcoind" , "fix": "Check bitcoind or config: "+RPCUSER+" "+RPCPASS+" "+RPCHOST+" "+RPCPORT})
+        exit()
 
 #check if private key provided produces correct address
 address = pybitcointools.privkey_to_address(listOptions['from_private_key'])
@@ -379,7 +408,11 @@ hex_transaction = hex_transaction + blocklocktime
 assert type(conn.decoderawtransaction(''.join(hex_transaction).lower())) == type({})
 
 #sign it
-signed_transaction = conn.signrawtransaction(''.join(hex_transaction))
+try:
+   signed_transaction = conn.signrawtransaction(''.join(hex_transaction))
+except Exception:
+    print json.dumps({ "status": "NOT OK", "error": "Wallet Locked" , "fix": "Manually unlock wallet (walletpassphrase <yourpassphrase> 120)"})
+    exit()
 
 #output final product as JSON
 print json.dumps({ "rawtransaction": signed_transaction })

--- a/scripts/generateTX51_SP.py
+++ b/scripts/generateTX51_SP.py
@@ -7,6 +7,7 @@ import hashlib
 import operator
 import bitcoinrpc
 import pybitcointools
+import getpass
 from decimal import *
 
 
@@ -24,8 +25,35 @@ JSON = sys.stdin.readlines()
 
 listOptions = json.loads(str(''.join(JSON)))
 
+USER=getpass.getuser()
+
 #sort out whether using local or remote API
 conn = bitcoinrpc.connect_to_local()
+try:
+    conn.getblockcount()
+except StandardError:
+    try:
+	with open('/home/'+USER+'/.bitcoin/bitcoin.conf') as fp:
+	    RPCPORT="8332"
+	    RPCHOST="localhost"
+	    for line in fp:
+		#print line
+		if line.split('=')[0] == "rpcuser":
+		    RPCUSER=line.split('=')[1].strip()
+		elif line.split('=')[0] == "rpcpassword":
+                    RPCPASS=line.split('=')[1].strip()
+		elif line.split('=')[0] == "rpcconnect":
+                    RPCHOST=line.split('=')[1].strip()
+		elif line.split('=')[0] == "rpcport":
+                    RPCPORT=line.split('=')[1].strip()
+    except IOError as e:
+	print "Unable to open conf file: ~/.bitcoin/bitcoin.conf"
+	exit()
+    try:
+	conn = bitcoinrpc.connect_to_remote(RPCUSER,RPCPASS,host=RPCHOST,port=RPCPORT,use_https=False)
+    except StandardError:
+	print json.dumps({ "status": "NOT OK", "error": "Can't connect to bitcoind" , "fix": "Check bitcoind or config: "+RPCUSER+" "+RPCPASS+" "+RPCHOST+" "+RPCPORT})
+        exit()
 
 #check if private key provided produces correct address
 address = pybitcointools.privkey_to_address(listOptions['from_private_key'])
@@ -411,7 +439,11 @@ hex_transaction = hex_transaction + blocklocktime
 assert type(conn.decoderawtransaction(''.join(hex_transaction).lower())) == type({})
 
 #sign it
-signed_transaction = conn.signrawtransaction(''.join(hex_transaction))
+try:
+   signed_transaction = conn.signrawtransaction(''.join(hex_transaction))
+except Exception:
+    print json.dumps({ "status": "NOT OK", "error": "Wallet Locked" , "fix": "Manually unlock wallet (walletpassphrase <yourpassphrase> 120)"}) 
+    exit()
 
 #output final product as JSON
 print json.dumps({ "rawtransaction": signed_transaction })


### PR DESCRIPTION
Added some logic to try to connect to a local bitcoind instance. if that fails look for a config file ~/.bitcoin/bitcoin.conf  and use the details in there to connect.  This file can also be used to connect to a remote node as long as the remote server variables are defined. 
"rpcuser"   -  username
"rpcpassword"  -  password
"rpcconnect" -  defaults to localhost but works for remote server ip.
      Note: Remote server needs to have whitelist setup (rpcallowip=) for the incoming connection.
"rpcport"  -  defaults to 8332
