### PR TITLE
bugfix: accept payment after sell cancel with following new sell

### DIFF
--- a/msc_validate.py
+++ b/msc_validate.py
@@ -22,6 +22,11 @@ alarm={}
 addr_dict={}
 tx_dict={}
 
+# invalidate tx due to "avoid changing history" issues
+invalidate_tx_list=['13fb62038d98ca4680c6295ba10d17b63c050ccde9c4cee7579fd2e148f25581', \
+                    '67d6302a45380289de0097afdae8d21a84b0a41221ca14319b3e4cdd8952a53b', \
+                    '8593540888247a9772fbe0fbcdd765df179779ae0c728e1fe83051f1bf0efe2f']
+
 # prepare lists for mastercoin and test
 sorted_currency_tx_list={'Mastercoin':[],'Test Mastercoin':[]} # list 0 for mastercoins, list 1 for test mastercoins
 sorted_currency_sell_tx_list={'Mastercoin':[],'Test Mastercoin':[]} # list 0 for mastercoins, list 1 for test mastercoins
@@ -423,7 +428,12 @@ def check_bitcoin_payment(t):
                                             # update seller address - reserved decreases, balance stays, offer updates (decreased at accept).
                                             satoshi_amount_closed=to_satoshi(amount_closed)
                                             satoshi_amount_accepted=to_satoshi(amount_accepted)
-                                            update_addr_dict(address, True, c, reserved=-satoshi_amount_closed, sold=satoshi_amount_closed, \
+                                            satoshi_amount_reserved=to_satoshi(amount_reserved)
+
+                                            # keep reserved at least zero
+                                            satoshi_reserved_update=min(satoshi_amount_closed, satoshi_amount_reserved)
+
+                                            update_addr_dict(address, True, c, reserved=-satoshi_reserved_update, sold=satoshi_amount_closed, \
                                                 sold_tx=sell_accept_tx, offer=-satoshi_amount_closed+satoshi_amount_accepted)
 
                                             # update buyer address - balance increases, accept decreases.
@@ -459,9 +469,13 @@ def check_bitcoin_payment(t):
                                             prev_closed=min(((part_bought-additional_part)*float(whole_sell_amount)+0.0), amount_accepted, amount_reserved)
                                             diff_closed=amount_closed-prev_closed
                                             satoshi_diff_closed=to_satoshi(diff_closed)
+                                            satoshi_amount_reserved=to_satoshi(amount_reserved)
+
+                                            # keep reserved at least zero
+                                            satoshi_reserved_update=min(satoshi_diff_closed, satoshi_amount_reserved)
 
                                             # update seller address
-                                            update_addr_dict(address, True, c, reserved=-satoshi_diff_closed, sold=satoshi_diff_closed, \
+                                            update_addr_dict(address, True, c, reserved=-satoshi_reserved_update, sold=satoshi_diff_closed, \
                                                 offer=-satoshi_diff_closed)
 
                                             # update buyer address - balance increases, accept decreases.
@@ -493,16 +507,29 @@ def check_bitcoin_payment(t):
                                             # remove alarm for accept
                                             remove_alarm(sell_accept_tx['tx_hash'])
 
-                                        # if not more left in the offer - close sell
-                                        if addr_dict[address][c]['offer'] == 0:
-                                            debug('... sell offer closed for '+address)
-                                            update_tx_dict(sell_offer_tx['tx_hash'], color='bgc-done', icon_text='Sell offer done')
-                                            # remove alarm for accept
-                                            debug('remove alarm for paid '+sell_accept_tx['tx_hash'])
-                                            remove_alarm(sell_accept_tx['tx_hash'])
+                                        # if not more left in the offer (and it is not updated) - close sell
+                                        sell_tx_updated=False
+                                        try:
+                                            if tx_dict[sell_offer_tx['tx_hash']][-1]['updated_by'] != None and tx_dict[sell_offer_tx['tx_hash']][-1]['updated_by'] != "unknown":
+                                                sell_tx_updated=True
+                                        except KeyError: # sell tx was not updated
+                                            pass
+
+                                        if not sell_tx_updated:
+                                            if addr_dict[address][c]['offer'] == 0:
+                                                debug('... sell offer closed for '+address)
+                                                update_tx_dict(sell_offer_tx['tx_hash'], color='bgc-done', icon_text='Sell offer done')
+                                                # remove alarm for accept
+                                                debug('remove alarm for paid '+sell_accept_tx['tx_hash'])
+                                                remove_alarm(sell_accept_tx['tx_hash'])
+                                            else:
+                                                debug('... sell offer is still open on '+address)
+                                                update_tx_dict(sell_offer_tx['tx_hash'], color='bgc-accepted-done', icon_text='Sell offer partially done')
                                         else:
-                                            debug('... sell offer is still open on '+address)
-                                            update_tx_dict(sell_offer_tx['tx_hash'], color='bgc-accepted-done', icon_text='Sell offer partially done')
+                                            debug('skip updating an updated sell offer on '+address)
+                                            # remove alarm for accept
+                                            debug('remove alarm for updated sell offer for paid '+sell_accept_tx['tx_hash'])
+                                            remove_alarm(sell_accept_tx['tx_hash'])
 
                                         # heavy debug
                                         debug_address(address, c, 'after bitcoin payment')
@@ -993,6 +1020,12 @@ def check_mastercoin_transaction(t, index=-1):
 
                     return True
         else:
+
+            # check history bugs (currently relevant for sell offer and accepts)
+            for tx_check in invalidate_tx_list:
+                if t['tx_hash'] == tx_check:
+                    mark_tx_invalid(t['tx_hash'], 'avoid changing history')
+
             # sell offer
             if t['tx_type_str']==transaction_type_dict['0014']:
                 debug('sell offer from '+t['from_address']+' '+t['tx_hash'])


### PR DESCRIPTION
The following steps introduced a bug:
1. sell offer accepted
2. sell offer cancelled
3. sell accept paid within allowed time after sell cancel
4. new sell offer on thie same address

The reserved amount was temporarly negative, and non zero reserved
was treated as an open sell offer. This fact invalidated the next
new sell offer on the same address.

The relevant parsing/validating path got fixed, but the invalid
transaction stays invalid so we don't change history:
https://masterchain.info/selloffer.html?tx=13fb62038d98ca4680c6295ba10d17b63c050ccde9c4cee7579fd2e148f25581&currency=MSC
The accepts of the invalidated sell offer get also invalidated:
https://masterchain.info/sellaccept.html?tx=8593540888247a9772fbe0fbcdd765df179779ae0c728e1fe83051f1bf0efe2f&currency=MSC
https://masterchain.info/sellaccept.html?tx=67d6302a45380289de0097afdae8d21a84b0a41221ca14319b3e4cdd8952a53b&currency=MSC
