### PR TITLE
Format "formatted_amount_accepted"

### DIFF
--- a/msc_validate.py
+++ b/msc_validate.py
@@ -1578,7 +1578,7 @@ def check_mastercoin_transaction(t, index=-1):
                     update_tx_dict(t['tx_hash'], bitcoin_required=formatted_decimal(bitcoin_required), \
                         sell_offer_txid=sell_offer_tx['tx_hash'], \
                         formatted_price_per_coin=sell_offer_tx['formatted_price_per_coin'], \
-                        formatted_amount_accepted=str(amount_accepted), \
+                        formatted_amount_accepted=formatted_decimal(amount_accepted), \
                         formatted_amount_bought='0.0', btc_offer_txid='unknown')
 
                     # heavy debug
@@ -1587,7 +1587,7 @@ def check_mastercoin_transaction(t, index=-1):
 
                     if amount_accepted > 0: # ignore 0 or negative accepts
                         # update sell accept
-                        update_tx_dict(t['tx_hash'], formatted_amount_accepted=amount_accepted, payment_done=False, payment_expired=False)
+                        update_tx_dict(t['tx_hash'], formatted_amount_accepted=formatted_decimal(amount_accepted), payment_done=False, payment_expired=False)
                         debug('add alarm for accept '+str(t))
                         add_alarm(t['tx_hash'])
 


### PR DESCRIPTION
"formatted_*" numbers are stored as formatted string. This was not the case for "formatted_amount_accepted", e.g.:

https://masterchain.info/tx/db8641b0e8bb6dc3694404668893a67163b5745095d51f83b72ba4cd6213f21c.json

"formatted_amount_accepted": 0.0018149999689180962,
"formatted_amount_bought": "0.0",
"formatted_amount_requested": "1.7",
"formatted_fee": "0.0001",
"formatted_price_per_coin": "0.07"

Which becomes:

"formatted_amount_accepted": "0.001815",

Balances and consensus checks were similar before and after applying this change.
